### PR TITLE
Add shadow form models, animations, and VFX

### DIFF
--- a/Assets/Effects/darkness_aura.effect.json
+++ b/Assets/Effects/darkness_aura.effect.json
@@ -1,0 +1,9 @@
+{
+  "type": "particle",
+  "rate": 20,
+  "lifetime": 0.6,
+  "texture": "rbxassetid://0",
+  "color": [0, 0, 0],
+  "size": [3, 3],
+  "spread": 1.5
+}

--- a/Assets/Effects/darkness_trail.effect.json
+++ b/Assets/Effects/darkness_trail.effect.json
@@ -1,0 +1,7 @@
+{
+  "type": "trail",
+  "color": [0, 0, 0],
+  "lifetime": 0.4,
+  "width": 2,
+  "texture": "rbxassetid://0"
+}

--- a/Assets/Models/Animations/ambush_leap.anim.json
+++ b/Assets/Models/Animations/ambush_leap.anim.json
@@ -1,0 +1,31 @@
+{
+  "fps": 30,
+  "length": 0.6,
+  "loop": false,
+  "keyframes": [
+    {
+      "time": 0.0,
+      "bones": {
+        "torso": {"position": [0, 0, 0], "rotation": [0, 0, 0]},
+        "leftLeg": {"rotation": [0, 0, 0]},
+        "rightLeg": {"rotation": [0, 0, 0]}
+      }
+    },
+    {
+      "time": 0.3,
+      "bones": {
+        "torso": {"position": [0, -0.2, 0], "rotation": [-30, 0, 0]},
+        "leftLeg": {"rotation": [30, 0, 0]},
+        "rightLeg": {"rotation": [30, 0, 0]}
+      }
+    },
+    {
+      "time": 0.6,
+      "bones": {
+        "torso": {"position": [0, 0.2, 0], "rotation": [60, 0, 0]},
+        "leftLeg": {"rotation": [-10, 0, 0]},
+        "rightLeg": {"rotation": [-10, 0, 0]}
+      }
+    }
+  ]
+}

--- a/Assets/Models/Animations/phase_dash.anim.json
+++ b/Assets/Models/Animations/phase_dash.anim.json
@@ -1,0 +1,31 @@
+{
+  "fps": 30,
+  "length": 0.4,
+  "loop": false,
+  "keyframes": [
+    {
+      "time": 0.0,
+      "bones": {
+        "torso": {"position": [0, 0, 0], "rotation": [0, 0, 0]},
+        "leftArm": {"rotation": [0, 0, 0]},
+        "rightArm": {"rotation": [0, 0, 0]}
+      }
+    },
+    {
+      "time": 0.2,
+      "bones": {
+        "torso": {"position": [0, 0, 0], "rotation": [20, 0, 0]},
+        "leftArm": {"rotation": [-30, 0, 0]},
+        "rightArm": {"rotation": [-30, 0, 0]}
+      }
+    },
+    {
+      "time": 0.4,
+      "bones": {
+        "torso": {"position": [0, 0, 0], "rotation": [0, 0, 0]},
+        "leftArm": {"rotation": [0, 0, 0]},
+        "rightArm": {"rotation": [0, 0, 0]}
+      }
+    }
+  ]
+}

--- a/Assets/Models/Animations/tag_attack.anim.json
+++ b/Assets/Models/Animations/tag_attack.anim.json
@@ -1,0 +1,31 @@
+{
+  "fps": 30,
+  "length": 0.5,
+  "loop": false,
+  "keyframes": [
+    {
+      "time": 0.0,
+      "bones": {
+        "torso": {"position": [0, 0, 0], "rotation": [0, 0, 0]},
+        "leftArm": {"rotation": [0, 0, 0]},
+        "rightArm": {"rotation": [0, 0, 0]}
+      }
+    },
+    {
+      "time": 0.25,
+      "bones": {
+        "torso": {"position": [0, 0, 0], "rotation": [10, 0, 0]},
+        "leftArm": {"rotation": [45, 0, 0]},
+        "rightArm": {"rotation": [45, 0, 0]}
+      }
+    },
+    {
+      "time": 0.5,
+      "bones": {
+        "torso": {"position": [0, 0, 0], "rotation": [0, 0, 0]},
+        "leftArm": {"rotation": [0, 0, 0]},
+        "rightArm": {"rotation": [0, 0, 0]}
+      }
+    }
+  ]
+}

--- a/Assets/Models/shadow_crystalline.obj
+++ b/Assets/Models/shadow_crystalline.obj
@@ -1,0 +1,18 @@
+# Crystalline shadow model: faceted diamond
+# Units in studs, origin at center
+
+o ShadowCrystalline
+v 0 1 0
+v 0.5 0.3 0.5
+v -0.5 0.3 0.5
+v -0.5 0.3 -0.5
+v 0.5 0.3 -0.5
+v 0 -1 0
+f 1 2 3
+f 1 3 4
+f 1 4 5
+f 1 5 2
+f 6 3 2
+f 6 4 3
+f 6 5 4
+f 6 2 5

--- a/Assets/Models/shadow_liquid.obj
+++ b/Assets/Models/shadow_liquid.obj
@@ -1,0 +1,18 @@
+# Liquid shadow model: wavy blob
+# Units in studs, origin at center
+
+o ShadowLiquid
+v 0 1 0
+v 0.6 0 0
+v 0 0.2 0.8
+v -0.6 0 0
+v 0 -0.2 -0.8
+v 0 -1 0
+f 1 2 3
+f 1 3 4
+f 1 4 5
+f 1 5 2
+f 6 3 2
+f 6 4 3
+f 6 5 4
+f 6 2 5

--- a/Assets/Models/shadow_rig.json
+++ b/Assets/Models/shadow_rig.json
@@ -1,0 +1,21 @@
+{
+  "bones": [
+    {
+      "name": "root",
+      "position": [0, 0, 0],
+      "children": [
+        {
+          "name": "torso",
+          "position": [0, 0.8, 0],
+          "children": [
+            {"name": "head", "position": [0, 0.7, 0]},
+            {"name": "leftArm", "position": [0.7, 0.6, 0]},
+            {"name": "rightArm", "position": [-0.7, 0.6, 0]},
+            {"name": "leftLeg", "position": [0.4, -0.8, 0]},
+            {"name": "rightLeg", "position": [-0.4, -0.8, 0]}
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Assets/Models/shadow_smoky.obj
+++ b/Assets/Models/shadow_smoky.obj
@@ -1,0 +1,18 @@
+# Smoky shadow model: simple sphere-like
+# Units in studs, origin at center
+
+o ShadowSmoky
+v 0 1 0
+v 1 0 0
+v 0 0 1
+v -1 0 0
+v 0 0 -1
+v 0 -1 0
+f 1 2 3
+f 1 3 4
+f 1 4 5
+f 1 5 2
+f 6 3 2
+f 6 4 3
+f 6 5 4
+f 6 2 5


### PR DESCRIPTION
## Summary
- add smoky, liquid, and crystalline shadow form meshes and rig
- create phase dash, ambush leap, and tag attack animation data
- provide darkness aura and trail effect definitions

## Testing
- `rg Smoke.server.lua -l`
- `rg TagFlow.server.lua -l`
- `rg Input.client.lua -l`
- `rg Perf.server.lua -l`
- `rg UX.client.lua -l`


------
https://chatgpt.com/codex/tasks/task_e_68a654024214832fa5d3c972b4e803ec