### PR TITLE
Add shadow ability sound effects and triggers

### DIFF
--- a/Assets/SFX/dark_surge.wav
+++ b/Assets/SFX/dark_surge.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09c771ccc41f6d3c7e8002d19079b8552679a4e5af9cd94bc9ab9554f27b0d9d
+size 70604

--- a/Assets/SFX/generate_sfx.py
+++ b/Assets/SFX/generate_sfx.py
@@ -72,6 +72,54 @@ def push_grunt():
 def push_impact():
     return single_step(0.3)
 
+def whisper_loop():
+    dur = 2.0
+    n = int(SAMPLE_RATE * dur)
+    samples = []
+    for i in range(n):
+        t = i / n
+        env = 0.2 + 0.8 * t  # grow over time
+        noise = random.uniform(-1, 1)
+        samples.append(noise * env * 0.2)
+    return samples
+
+def phase_dash_echo():
+    dur = 0.5
+    n = int(SAMPLE_RATE * dur)
+    base = []
+    for i in range(n):
+        t = i / SAMPLE_RATE
+        env = math.exp(-6 * t)
+        base.append(math.sin(2 * math.pi * 200 * t) * env * 0.6)
+    echo_gap = int(SAMPLE_RATE * 0.1)
+    echo = [s * 0.5 for s in base]
+    return base + [0.0] * echo_gap + echo
+
+def dark_surge_blackout():
+    dur = 0.8
+    n = int(SAMPLE_RATE * dur)
+    samples = []
+    for i in range(n):
+        t = i / SAMPLE_RATE
+        env = math.exp(-3 * t)
+        base = math.sin(2 * math.pi * 40 * t) + 0.5 * math.sin(2 * math.pi * 80 * t)
+        samples.append(base * env * 0.7)
+    return samples
+
+def tag_impact():
+    return single_step(0.15)
+
+def infection_transform():
+    dur = 1.0
+    n = int(SAMPLE_RATE * dur)
+    samples = []
+    for i in range(n):
+        t = i / SAMPLE_RATE
+        freq = 60 + 240 * (t / dur)
+        env = math.exp(-3 * t)
+        samples.append(math.sin(2 * math.pi * freq * t) * env * 0.6)
+    return samples
+
 os.makedirs('Assets/SFX', exist_ok=True)
 write_wave('Assets/SFX/footstep.wav', footstep_loop())
 write_wave('Assets/SFX/sprint_breathing.wav', breathing_loop())
@@ -80,3 +128,8 @@ write_wave('Assets/SFX/heartbeat_slow.wav', heartbeat_loop(60))
 write_wave('Assets/SFX/heartbeat_fast.wav', heartbeat_loop(120))
 write_wave('Assets/SFX/push_grunt.wav', push_grunt())
 write_wave('Assets/SFX/push_impact.wav', push_impact())
+write_wave('Assets/SFX/whisper_loop.wav', whisper_loop())
+write_wave('Assets/SFX/phase_dash.wav', phase_dash_echo())
+write_wave('Assets/SFX/dark_surge.wav', dark_surge_blackout())
+write_wave('Assets/SFX/tag_impact.wav', tag_impact())
+write_wave('Assets/SFX/infection_transform.wav', infection_transform())

--- a/Assets/SFX/infection_transform.wav
+++ b/Assets/SFX/infection_transform.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e15b6cf1d2b24a2ad6b67e1dd26c286fa5eda7d31febea00f0206ab6b7446451
+size 88244

--- a/Assets/SFX/phase_dash.wav
+++ b/Assets/SFX/phase_dash.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:317f87f7c5eeb6cbcdcea0f410d63c2d2b14a1d19c0d5e5587489250b66e4795
+size 97064

--- a/Assets/SFX/tag_impact.wav
+++ b/Assets/SFX/tag_impact.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96b3982218cb6cf899e5d8fabe1d3147c909287b5161a244b01f08972020a646
+size 13274

--- a/Assets/SFX/whisper_loop.wav
+++ b/Assets/SFX/whisper_loop.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34ddafc4e85701efbc20233c8f15bda509e14803feeeb4776b911aa2ca409166
+size 176444

--- a/Players/Shadow/DarkSurge.lua
+++ b/Players/Shadow/DarkSurge.lua
@@ -1,5 +1,7 @@
 local Players = game:GetService("Players")
 
+local SURGE_SOUND_ID = "rbxassetid://0" -- replace with uploaded dark surge asset id
+
 local DarkSurge = {}
 DarkSurge.__index = DarkSurge
 
@@ -12,6 +14,11 @@ function DarkSurge.new(character)
     local self = setmetatable({}, DarkSurge)
     self.character = character
     self.lastUsed = 0
+    local root = character:WaitForChild("HumanoidRootPart")
+    self.sound = Instance.new("Sound")
+    self.sound.SoundId = SURGE_SOUND_ID
+    self.sound.Volume = 0.7
+    self.sound.Parent = root
     return self
 end
 
@@ -32,6 +39,9 @@ function DarkSurge:cast()
     local root = self.character:FindFirstChild("HumanoidRootPart")
     if not root then return end
     self.lastUsed = os.clock()
+    if self.sound then
+        self.sound:Play()
+    end
     local origin = root.Position
     for _,plr in ipairs(Players:GetPlayers()) do
         local char = plr.Character

--- a/Players/Shadow/InfectionManager.lua
+++ b/Players/Shadow/InfectionManager.lua
@@ -1,3 +1,8 @@
+local Debris = game:GetService("Debris")
+
+local TAG_SOUND_ID = "rbxassetid://0" -- replace with uploaded tag impact asset id
+local INFECT_SOUND_ID = "rbxassetid://0" -- replace with uploaded infection transform asset id
+
 local InfectionManager = {}
 InfectionManager.__index = InfectionManager
 
@@ -20,6 +25,18 @@ function InfectionManager:onTagged(player)
     if not self.enabled then return end
     if not player then return end
     self.pending[player] = true
+    local char = player.Character
+    if char then
+        local root = char:FindFirstChild("HumanoidRootPart")
+        if root then
+            local snd = Instance.new("Sound")
+            snd.SoundId = TAG_SOUND_ID
+            snd.Volume = 1
+            snd.Parent = root
+            snd:Play()
+            Debris:AddItem(snd, 2)
+        end
+    end
     task.delay(3, function()
         if self.enabled and self.pending[player] then
             self.pending[player] = nil
@@ -34,6 +51,15 @@ function InfectionManager:convert(player)
         local humanoid = char:FindFirstChildOfClass("Humanoid")
         if humanoid then
             humanoid.Health = humanoid.MaxHealth
+        end
+        local root = char:FindFirstChild("HumanoidRootPart")
+        if root then
+            local snd = Instance.new("Sound")
+            snd.SoundId = INFECT_SOUND_ID
+            snd.Volume = 1
+            snd.Parent = root
+            snd:Play()
+            Debris:AddItem(snd, 2)
         end
     end
     player.Team = "Shadow"

--- a/Players/Shadow/PhaseDash.lua
+++ b/Players/Shadow/PhaseDash.lua
@@ -1,5 +1,7 @@
 local Debris = game:GetService("Debris")
 
+local DASH_SOUND_ID = "rbxassetid://0" -- replace with uploaded phase dash asset id
+
 local PhaseDash = {}
 PhaseDash.__index = PhaseDash
 
@@ -11,6 +13,11 @@ function PhaseDash.new(character)
     local self = setmetatable({}, PhaseDash)
     self.character = character
     self.lastUsed = 0
+    local root = character:WaitForChild("HumanoidRootPart")
+    self.sound = Instance.new("Sound")
+    self.sound.SoundId = DASH_SOUND_ID
+    self.sound.Volume = 0.6
+    self.sound.Parent = root
     return self
 end
 
@@ -43,6 +50,9 @@ function PhaseDash:dash(direction)
     local targetPos = root.Position + direction * PhaseDash.DASH_DISTANCE
     createAfterImage(self.character)
     self.lastUsed = os.clock()
+    if self.sound then
+        self.sound:Play()
+    end
     root.CFrame = CFrame.new(targetPos)
 end
 


### PR DESCRIPTION
## Summary
- generate new SFX for phase dash, dark surge, tag impact, infection transform, and ambient whispers
- hook phase dash and dark surge to play their new sounds
- play tag impact and infection transform SFX during infection events

## Testing
- `python -m py_compile Assets/SFX/generate_sfx.py`
- `luac -p Players/Shadow/PhaseDash.lua Players/Shadow/DarkSurge.lua Players/Shadow/InfectionManager.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a654f500fc832f92ee1fa7dc0d9fc1