### PR TITLE
Implement darkness zones with player visibility and speed effects

### DIFF
--- a/Game/MatchController.lua
+++ b/Game/MatchController.lua
@@ -107,10 +107,10 @@ function MatchController:assignRoles()
 
     self.roles = {}
     for i, plr in ipairs(pool) do
-        if i <= targetShadows then
-            self.roles[plr] = "Shadow"
-        else
-            self.roles[plr] = "Survivor"
+        local role = i <= targetShadows and "Shadow" or "Survivor"
+        self.roles[plr] = role
+        if plr.SetAttribute then
+            plr:SetAttribute("Role", role)
         end
     end
 end

--- a/Players/Survivor/FlashlightComponent.lua
+++ b/Players/Survivor/FlashlightComponent.lua
@@ -1,4 +1,5 @@
 local RunService = game:GetService("RunService")
+local DarknessManager = require(game:GetService("ReplicatedStorage"):WaitForChild("World"):WaitForChild("DarknessManager"))
 
 local FlashlightComponent = {}
 FlashlightComponent.__index = FlashlightComponent
@@ -13,6 +14,8 @@ function FlashlightComponent.new(light)
     self.recharging = false
     if self.light then
         self.light.Enabled = false
+        self.baseBrightness = self.light.Brightness
+        self.baseRange = self.light.Range
     end
     self.flickerSound = Instance.new("Sound")
     self.flickerSound.SoundId = "rbxassetid://0" -- replace with uploaded flicker asset id
@@ -41,6 +44,11 @@ end
 
 function FlashlightComponent:update(dt)
     if self.light and self.light.Enabled then
+        local parent = self.light.Parent
+        local pos = parent and parent.Position or Vector3.new()
+        local mult = DarknessManager and DarknessManager:GetLightMultiplier(pos) or 1
+        self.light.Brightness = self.baseBrightness * mult
+        self.light.Range = self.baseRange * mult
         self.battery = math.max(0, self.battery - dt)
         if self.battery <= 0 then
             self.light.Enabled = false

--- a/World/DarknessManager.lua
+++ b/World/DarknessManager.lua
@@ -1,0 +1,134 @@
+local Players = game:GetService("Players")
+local RunService = game:GetService("RunService")
+
+local DarknessManager = {}
+DarknessManager.__index = DarknessManager
+
+DarknessManager.EXPANSION_INTERVAL = 90
+DarknessManager.EXPANSION_AMOUNT = 20
+DarknessManager.MAX_RADIUS = 200
+DarknessManager.SHADOW_SPEED_BUFF = 1.12
+DarknessManager.SURVIVOR_VIS_TRANSPARENCY = 0.4
+DarknessManager.SHADOW_LIGHT_TRANSPARENCY = 0.55
+DarknessManager.SHADOW_DARK_TRANSPARENCY = 0.2
+
+function DarknessManager.new()
+    local self = setmetatable({}, DarknessManager)
+    self.zones = {}
+    self.running = false
+    self._heartbeat = nil
+    return self
+end
+
+function DarknessManager:AddZone(position, radius)
+    table.insert(self.zones, {center = position, radius = radius or 0})
+end
+
+function DarknessManager:IsInDarkness(position)
+    for _, zone in ipairs(self.zones) do
+        if (position - zone.center).Magnitude <= zone.radius then
+            return true
+        end
+    end
+    return false
+end
+
+function DarknessManager:GetLightMultiplier(position)
+    return self:IsInDarkness(position) and 0.5 or 1
+end
+
+function DarknessManager:BeginExpansion()
+    if self.running then
+        return
+    end
+    self.running = true
+    self:_scheduleExpansion()
+    self._heartbeat = RunService.Heartbeat:Connect(function()
+        self:_updatePlayers()
+    end)
+end
+
+function DarknessManager:_scheduleExpansion()
+    if not self.running then
+        return
+    end
+    task.delay(DarknessManager.EXPANSION_INTERVAL, function()
+        self:ExpandZones()
+        self:_scheduleExpansion()
+    end)
+end
+
+function DarknessManager:ExpandZones()
+    for _, zone in ipairs(self.zones) do
+        zone.radius = math.min(zone.radius + DarknessManager.EXPANSION_AMOUNT, DarknessManager.MAX_RADIUS)
+    end
+end
+
+function DarknessManager:_updatePlayers()
+    for _, plr in ipairs(Players:GetPlayers()) do
+        local char = plr.Character
+        if char then
+            local root = char:FindFirstChild("HumanoidRootPart")
+            local hum = char:FindFirstChildOfClass("Humanoid")
+            if root and hum then
+                local inDark = self:IsInDarkness(root.Position)
+                local role = plr:GetAttribute("Role")
+                if role == "Survivor" then
+                    self:_applySurvivorEffects(char, inDark)
+                elseif role == "Shadow" then
+                    self:_applyShadowEffects(char, hum, inDark)
+                end
+            end
+        end
+    end
+end
+
+function DarknessManager:_applySurvivorEffects(char, inDark)
+    for _, part in ipairs(char:GetDescendants()) do
+        if part:IsA("BasePart") then
+            local base = part:GetAttribute("BaseTransparency")
+            if not base then
+                part:SetAttribute("BaseTransparency", part.Transparency)
+                base = part.Transparency
+            end
+            if inDark then
+                part.Transparency = math.clamp(base + DarknessManager.SURVIVOR_VIS_TRANSPARENCY, 0, 1)
+            else
+                part.Transparency = base
+            end
+        end
+    end
+end
+
+function DarknessManager:_applyShadowEffects(char, hum, inDark)
+    local baseSpeed = hum:GetAttribute("BaseWalkSpeed")
+    if not baseSpeed then
+        hum:SetAttribute("BaseWalkSpeed", hum.WalkSpeed)
+        baseSpeed = hum.WalkSpeed
+    end
+    if inDark then
+        hum.WalkSpeed = baseSpeed * DarknessManager.SHADOW_SPEED_BUFF
+    else
+        hum.WalkSpeed = baseSpeed
+    end
+    for _, part in ipairs(char:GetDescendants()) do
+        if part:IsA("BasePart") then
+            if inDark then
+                part.Transparency = DarknessManager.SHADOW_DARK_TRANSPARENCY
+            else
+                part.Transparency = DarknessManager.SHADOW_LIGHT_TRANSPARENCY
+            end
+        end
+    end
+end
+
+function DarknessManager:Destroy()
+    if self._heartbeat then
+        self._heartbeat:Disconnect()
+        self._heartbeat = nil
+    end
+    self.running = false
+end
+
+return DarknessManager
+


### PR DESCRIPTION
## Summary
- add DarknessManager to manage expanding radial dark zones
- scale survivor flashlight strength and visibility based on darkness
- boost shadow speed and adjust opacity when inside dark areas

## Testing
- `luac -p World/DarknessManager.lua Players/Survivor/FlashlightComponent.lua Game/MatchController.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a657f1fdcc832fb6ea7800e1adeec7