### PR TITLE
Add StVerityWing interior with keys and audio zones

### DIFF
--- a/Assets/SFX/ambient_hum.wav
+++ b/Assets/SFX/ambient_hum.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a206e43008b62afe89fec2ebc83cdc966838ded760ed96216b411e6fd193ce5b
+size 176444

--- a/Assets/SFX/creaking_metal.wav
+++ b/Assets/SFX/creaking_metal.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e41372c9b8c56367e9c35b5a96a989c642b99c2cfe763c91dcd515a2e333199e
+size 176444

--- a/Assets/SFX/generate_sfx.py
+++ b/Assets/SFX/generate_sfx.py
@@ -121,6 +121,23 @@ def infection_transform():
     return samples
 
 os.makedirs('Assets/SFX', exist_ok=True)
+
+def ambient_hum():
+    dur = 2.0
+    n = int(SAMPLE_RATE * dur)
+    return [math.sin(2 * math.pi * 50 * (i / SAMPLE_RATE)) * 0.1 for i in range(n)]
+
+def metal_creak():
+    dur = 2.0
+    n = int(SAMPLE_RATE * dur)
+    samples = []
+    for i in range(n):
+        t = i / SAMPLE_RATE
+        noise = random.uniform(-0.5, 0.5)
+        env = math.exp(-3 * t)
+        samples.append((math.sin(2 * math.pi * 30 * t) + noise) * env * 0.4)
+    return samples
+
 write_wave('Assets/SFX/footstep.wav', footstep_loop())
 write_wave('Assets/SFX/sprint_breathing.wav', breathing_loop())
 write_wave('Assets/SFX/flashlight_flicker.wav', flashlight_flicker())
@@ -133,3 +150,5 @@ write_wave('Assets/SFX/phase_dash.wav', phase_dash_echo())
 write_wave('Assets/SFX/dark_surge.wav', dark_surge_blackout())
 write_wave('Assets/SFX/tag_impact.wav', tag_impact())
 write_wave('Assets/SFX/infection_transform.wav', infection_transform())
+write_wave('Assets/SFX/ambient_hum.wav', ambient_hum())
+write_wave('Assets/SFX/creaking_metal.wav', metal_creak())

--- a/Players/Survivor/UseComponent.lua
+++ b/Players/Survivor/UseComponent.lua
@@ -1,4 +1,5 @@
 local ContextActionService = game:GetService("ContextActionService")
+local Players = game:GetService("Players")
 
 local UseComponent = {}
 UseComponent.__index = UseComponent
@@ -37,11 +38,20 @@ function UseComponent:Use()
             if self.flashlight then
                 self.flashlight:startRecharge(obj)
             end
+        elseif useType == "Key" then
+            self:pickupKey(obj)
         end
     end
 end
 
 function UseComponent:useDoor(part)
+    local keyId = part:GetAttribute("KeyRequired")
+    if keyId then
+        local player = Players:GetPlayerFromCharacter(self.character)
+        if not (player and player:GetAttribute(keyId)) then
+            return
+        end
+    end
     local hinge = part.Parent:FindFirstChildWhichIsA("HingeConstraint", true)
     if hinge then
         local target = hinge.TargetAngle == 0 and 90 or 0
@@ -54,6 +64,15 @@ function UseComponent:useSwitch(part)
     if event then
         event:Fire()
     end
+end
+
+function UseComponent:pickupKey(part)
+    local keyId = part:GetAttribute("KeyId") or part.Name
+    local player = Players:GetPlayerFromCharacter(self.character)
+    if player then
+        player:SetAttribute(keyId, true)
+    end
+    part:Destroy()
 end
 
 function UseComponent:Destroy()

--- a/World/StVerityWing.lua
+++ b/World/StVerityWing.lua
@@ -1,0 +1,186 @@
+local Map = {}
+Map.__index = Map
+
+Map.MAX_PARTS = 200
+
+function Map.new(parent)
+    local self = setmetatable({}, Map)
+    self.model = Instance.new("Model")
+    self.model.Name = "StVerityWing"
+    self.model.Parent = parent or workspace
+    self.partCount = 0
+    return self
+end
+
+function Map:_addPart(part)
+    part.Parent = self.model
+    self.partCount = self.partCount + 1
+end
+
+function Map:_createFloor(cframe, size)
+    local floor = Instance.new("Part")
+    floor.Name = "Floor"
+    floor.Anchored = true
+    floor.Size = size
+    floor.CFrame = cframe
+    floor.Material = Enum.Material.Concrete
+    self:_addPart(floor)
+end
+
+function Map:_createWall(cframe, size)
+    local wall = Instance.new("Part")
+    wall.Name = "Wall"
+    wall.Anchored = true
+    wall.Size = size
+    wall.CFrame = cframe
+    wall.Material = Enum.Material.Metal
+    self:_addPart(wall)
+end
+
+function Map:_createStairs(cframe, size)
+    local stairs = Instance.new("Part")
+    stairs.Name = "Stairs"
+    stairs.Anchored = true
+    stairs.Size = size
+    stairs.CFrame = cframe * CFrame.Angles(math.rad(-30), 0, 0)
+    stairs.Material = Enum.Material.Metal
+    self:_addPart(stairs)
+end
+
+function Map:_createWingLights(positions, switchPos)
+    local lights = {}
+    for _, pos in ipairs(positions) do
+        local holder = Instance.new("Part")
+        holder.Name = "Light"
+        holder.Anchored = true
+        holder.CanCollide = false
+        holder.Transparency = 1
+        holder.Size = Vector3.new(1,1,1)
+        holder.CFrame = CFrame.new(pos)
+        self:_addPart(holder)
+
+        local light = Instance.new("PointLight")
+        light.Brightness = 2
+        light.Range = 20
+        light.Enabled = false
+        light.Parent = holder
+        table.insert(lights, light)
+    end
+
+    local switch = Instance.new("Part")
+    switch.Name = "LightSwitch"
+    switch.Anchored = true
+    switch.Size = Vector3.new(2,3,1)
+    switch.CFrame = CFrame.new(switchPos)
+    switch.Material = Enum.Material.Metal
+    switch:SetAttribute("UseType", "Switch")
+    self:_addPart(switch)
+
+    local event = Instance.new("BindableEvent")
+    event.Parent = switch
+    local on = false
+    event.Event:Connect(function()
+        on = not on
+        for _, l in ipairs(lights) do
+            l.Enabled = on
+        end
+    end)
+end
+
+function Map:_createKey(position, keyId)
+    local key = Instance.new("Part")
+    key.Name = keyId .. "Key"
+    key.Anchored = true
+    key.Size = Vector3.new(1,1,1)
+    key.CFrame = CFrame.new(position)
+    key.Color = Color3.new(1,1,0)
+    key:SetAttribute("UseType", "Key")
+    key:SetAttribute("KeyId", keyId)
+    self:_addPart(key)
+end
+
+function Map:_createLockedDoor(cframe, size, keyId)
+    local anchor = Instance.new("Part")
+    anchor.Name = "DoorAnchor"
+    anchor.Anchored = true
+    anchor.Transparency = 1
+    anchor.Size = Vector3.new(1, size.Y, 1)
+    anchor.CFrame = cframe * CFrame.new(-size.X/2,0,0)
+    self:_addPart(anchor)
+
+    local door = Instance.new("Part")
+    door.Name = "Door"
+    door.Size = size
+    door.Anchored = false
+    door.CFrame = cframe
+    door.Material = Enum.Material.Metal
+    door:SetAttribute("UseType", "Door")
+    if keyId then
+        door:SetAttribute("KeyRequired", keyId)
+    end
+    self:_addPart(door)
+
+    local hinge = Instance.new("HingeConstraint")
+    hinge.Part0 = anchor
+    hinge.Part1 = door
+    hinge.TargetAngle = 0
+    hinge.AngularSpeed = 2
+    hinge.Parent = door
+end
+
+function Map:_createAudioZone(position, soundId, volume)
+    local part = Instance.new("Part")
+    part.Name = "AudioEmitter"
+    part.Anchored = true
+    part.CanCollide = false
+    part.Transparency = 1
+    part.Size = Vector3.new(1,1,1)
+    part.CFrame = CFrame.new(position)
+    self:_addPart(part)
+
+    local sound = Instance.new("Sound")
+    sound.SoundId = soundId or "rbxassetid://0"
+    sound.Looped = true
+    sound.Volume = volume or 0.3
+    sound.Playing = true
+    sound.Parent = part
+end
+
+function Map:Build()
+    -- floors
+    self:_createFloor(CFrame.new(0,0,0), Vector3.new(100,1,60))
+    self:_createFloor(CFrame.new(0,10,0), Vector3.new(100,1,60))
+
+    -- outer walls
+    local height, w, d, t = 20, 100, 60, 2
+    local walls = {
+        {CFrame.new(0, height/2, -d/2 + t/2), Vector3.new(w, height, t)},
+        {CFrame.new(0, height/2,  d/2 - t/2), Vector3.new(w, height, t)},
+        {CFrame.new(-w/2 + t/2, height/2, 0), Vector3.new(t, height, d)},
+        {CFrame.new( w/2 - t/2, height/2, 0), Vector3.new(t, height, d)},
+    }
+    for _, data in ipairs(walls) do
+        self:_createWall(data[1], data[2])
+    end
+
+    -- stairs to second floor
+    self:_createStairs(CFrame.new(-40,2.5,-25), Vector3.new(10,5,30))
+
+    -- wing lights
+    self:_createWingLights({Vector3.new(-30,15,-20), Vector3.new(-30,15,20)}, Vector3.new(-45,5,0))
+    self:_createWingLights({Vector3.new(30,15,-20), Vector3.new(30,15,20)}, Vector3.new(45,5,0))
+
+    -- key and locked door
+    self:_createKey(Vector3.new(-40,1,20), "Main")
+    self:_createLockedDoor(CFrame.new(0,5,30), Vector3.new(6,10,1), "Main")
+
+    -- audio zones
+    self:_createAudioZone(Vector3.new(0,5,0), "rbxassetid://0", 0.2)
+    self:_createAudioZone(Vector3.new(0,15,0), "rbxassetid://0", 0.3)
+
+    assert(self.partCount <= Map.MAX_PARTS, string.format("part budget exceeded (%d > %d)", self.partCount, Map.MAX_PARTS))
+    return self.model
+end
+
+return Map
+


### PR DESCRIPTION
## Summary
- add StVerityWing multi-level interior with toggleable wing lights
- implement key pickup and locked door checks
- generate ambient hum and creaking metal sounds

## Testing
- `python Assets/SFX/generate_sfx.py`


------
https://chatgpt.com/codex/tasks/task_e_68a65e5777c4832faef01ab6c1bcbe8b