### PR TITLE
Implement rewards, cosmetics, and currency UI

### DIFF
--- a/Game/MatchController.lua
+++ b/Game/MatchController.lua
@@ -1,4 +1,6 @@
 local Players = game:GetService("Players")
+local RewardsManager = require(script.Parent.Parent.Systems.RewardsManager)
+local CosmeticsManager = require(script.Parent.Parent.Systems.CosmeticsManager)
 
 local MatchController = {}
 MatchController.__index = MatchController
@@ -45,6 +47,7 @@ end
 
 local HuntPhase = {}
 function HuntPhase:enter(controller)
+    controller.RewardsManager:BeginMatch(controller.roles)
     controller:triggerDarkness()
     controller:schedule(HUNT_MIN_DURATION, function()
         controller:transitionTo(EndgamePhase)
@@ -62,6 +65,7 @@ end
 local ResultsPhase = {}
 function ResultsPhase:enter(controller)
     controller:calculateResults()
+    controller.RewardsManager:Distribute(controller.winningTeam)
     controller:schedule(RESULTS_DURATION, function()
         controller:transitionTo(LobbyPhase)
     end)
@@ -72,6 +76,8 @@ function MatchController.new()
     local self = setmetatable({}, MatchController)
     self.phase = nil
     self.roles = {}
+    self.RewardsManager = RewardsManager.new()
+    self.CosmeticsManager = CosmeticsManager.new()
     return self
 end
 

--- a/Systems/CosmeticsManager.lua
+++ b/Systems/CosmeticsManager.lua
@@ -1,0 +1,64 @@
+local Players = game:GetService("Players")
+
+local CosmeticsManager = {}
+CosmeticsManager.__index = CosmeticsManager
+
+local function contains(t, v)
+    for _, item in ipairs(t) do
+        if item == v then
+            return true
+        end
+    end
+    return false
+end
+
+function CosmeticsManager.new()
+    local self = setmetatable({}, CosmeticsManager)
+    self.data = {}
+    Players.PlayerRemoving:Connect(function(plr)
+        self.data[plr] = nil
+    end)
+    return self
+end
+
+function CosmeticsManager:_get(plr)
+    local data = self.data[plr]
+    if not data then
+        data = {
+            Owned = {Survivor = {}, Shadow = {}},
+            Equipped = {Survivor = nil, Shadow = nil}
+        }
+        self.data[plr] = data
+    end
+    return data
+end
+
+function CosmeticsManager:Unlock(plr, role, cosmetic)
+    local data = self:_get(plr)
+    local list = data.Owned[role]
+    if not contains(list, cosmetic) then
+        table.insert(list, cosmetic)
+    end
+end
+
+function CosmeticsManager:Equip(plr, role, cosmetic)
+    local data = self:_get(plr)
+    local list = data.Owned[role]
+    if contains(list, cosmetic) then
+        data.Equipped[role] = cosmetic
+        plr:SetAttribute(role.."Cosmetic", cosmetic)
+    end
+end
+
+function CosmeticsManager:GetOwned(plr, role)
+    local data = self:_get(plr)
+    return data.Owned[role]
+end
+
+function CosmeticsManager:GetEquipped(plr, role)
+    local data = self:_get(plr)
+    return data.Equipped[role]
+end
+
+return CosmeticsManager
+

--- a/Systems/RewardsManager.lua
+++ b/Systems/RewardsManager.lua
@@ -1,0 +1,115 @@
+local RewardsManager = {}
+RewardsManager.__index = RewardsManager
+
+local REWARDS = {
+    SurvivePerMin = 6,
+    EscapeBonus = 40,
+    Assist = 6,
+    Tag = 10,
+    MultiTag = 6,
+    AmbushTag = 8,
+    Wipe = 40,
+}
+
+local ESSENCE_CHANCE = 0.06
+local random = Random.new()
+
+function RewardsManager.new()
+    local self = setmetatable({}, RewardsManager)
+    self.startTime = 0
+    self.playerStats = {}
+    return self
+end
+
+function RewardsManager:BeginMatch(roles)
+    self.startTime = os.clock()
+    self.playerStats = {}
+    for plr, role in pairs(roles) do
+        self.playerStats[plr] = {
+            role = role,
+            assists = 0,
+            tags = 0,
+            multi = 0,
+            ambush = 0,
+            escaped = false,
+            eliminatedAt = nil,
+            wipe = false,
+        }
+    end
+end
+
+function RewardsManager:RecordAssist(plr)
+    local stats = self.playerStats[plr]
+    if stats then
+        stats.assists = stats.assists + 1
+    end
+end
+
+function RewardsManager:RecordTag(plr, isMulti, isAmbush)
+    local stats = self.playerStats[plr]
+    if stats then
+        stats.tags = stats.tags + 1
+        if isMulti then
+            stats.multi = stats.multi + 1
+        end
+        if isAmbush then
+            stats.ambush = stats.ambush + 1
+        end
+    end
+end
+
+function RewardsManager:RecordEscape(plr)
+    local stats = self.playerStats[plr]
+    if stats then
+        stats.escaped = true
+        stats.eliminatedAt = os.clock()
+    end
+end
+
+function RewardsManager:RecordElimination(plr)
+    local stats = self.playerStats[plr]
+    if stats and not stats.eliminatedAt then
+        stats.eliminatedAt = os.clock()
+    end
+end
+
+function RewardsManager:RecordWipe(plr)
+    local stats = self.playerStats[plr]
+    if stats then
+        stats.wipe = true
+    end
+end
+
+function RewardsManager:_award(plr, coins, essence)
+    local currentCoins = plr:GetAttribute("Coins") or 0
+    plr:SetAttribute("Coins", currentCoins + coins)
+    local currentEssence = plr:GetAttribute("Essence") or 0
+    plr:SetAttribute("Essence", currentEssence + essence)
+end
+
+function RewardsManager:Distribute(winningTeam)
+    for plr, stats in pairs(self.playerStats) do
+        local coins = 0
+        if stats.role == "Survivor" then
+            local endTime = stats.eliminatedAt or os.clock()
+            local minutes = math.floor((endTime - self.startTime) / 60)
+            coins = coins + minutes * REWARDS.SurvivePerMin
+            if stats.escaped then
+                coins = coins + REWARDS.EscapeBonus
+            end
+            coins = coins + stats.assists * REWARDS.Assist
+        else
+            coins = coins + stats.tags * REWARDS.Tag
+            coins = coins + stats.multi * REWARDS.MultiTag
+            coins = coins + stats.ambush * REWARDS.AmbushTag
+            if stats.wipe or winningTeam == "Shadows" then
+                coins = coins + REWARDS.Wipe
+            end
+        end
+        local essence = random:NextNumber() < ESSENCE_CHANCE and 1 or 0
+        self:_award(plr, coins, essence)
+    end
+end
+
+return RewardsManager
+

--- a/UI/CosmeticLoadout.lua
+++ b/UI/CosmeticLoadout.lua
@@ -1,0 +1,54 @@
+local Players = game:GetService("Players")
+
+local CosmeticLoadout = {}
+CosmeticLoadout.__index = CosmeticLoadout
+
+function CosmeticLoadout.new(manager, role)
+    local self = setmetatable({}, CosmeticLoadout)
+    local player = Players.LocalPlayer
+    local gui = Instance.new("ScreenGui")
+    gui.Name = "CosmeticLoadout"
+    gui.ResetOnSpawn = false
+    gui.Parent = player:WaitForChild("PlayerGui")
+
+    local frame = Instance.new("Frame")
+    frame.Name = "CosmeticFrame"
+    frame.Size = UDim2.fromOffset(200, 200)
+    frame.Position = UDim2.new(1, -210, 0, 10)
+    frame.BackgroundTransparency = 0.5
+    frame.Parent = gui
+
+    self.gui = gui
+    self.frame = frame
+    self.player = player
+    self.manager = manager
+    self.role = role
+
+    self:Refresh()
+    return self
+end
+
+function CosmeticLoadout:Refresh()
+    self.frame:ClearAllChildren()
+    local cosmetics = self.manager:GetOwned(self.player, self.role)
+    for i, name in ipairs(cosmetics) do
+        local button = Instance.new("TextButton")
+        button.Size = UDim2.fromOffset(180, 24)
+        button.Position = UDim2.new(0, 10, 0, (i - 1) * 26)
+        button.Text = name
+        button.Parent = self.frame
+        button.MouseButton1Click:Connect(function()
+            self.manager:Equip(self.player, self.role, name)
+        end)
+    end
+end
+
+function CosmeticLoadout:Destroy()
+    if self.gui then
+        self.gui:Destroy()
+        self.gui = nil
+    end
+end
+
+return CosmeticLoadout
+

--- a/UI/CurrencyDisplay.lua
+++ b/UI/CurrencyDisplay.lua
@@ -1,0 +1,61 @@
+local Players = game:GetService("Players")
+
+local CurrencyDisplay = {}
+CurrencyDisplay.__index = CurrencyDisplay
+
+function CurrencyDisplay.new()
+    local self = setmetatable({}, CurrencyDisplay)
+    local player = Players.LocalPlayer
+    local gui = Instance.new("ScreenGui")
+    gui.Name = "CurrencyDisplay"
+    gui.ResetOnSpawn = false
+    gui.Parent = player:WaitForChild("PlayerGui")
+
+    local coinsLabel = Instance.new("TextLabel")
+    coinsLabel.Name = "CoinsLabel"
+    coinsLabel.Size = UDim2.fromOffset(150, 24)
+    coinsLabel.Position = UDim2.new(0, 10, 0, 10)
+    coinsLabel.BackgroundTransparency = 0.5
+    coinsLabel.TextXAlignment = Enum.TextXAlignment.Left
+    coinsLabel.Parent = gui
+
+    local essenceLabel = Instance.new("TextLabel")
+    essenceLabel.Name = "EssenceLabel"
+    essenceLabel.Size = UDim2.fromOffset(150, 24)
+    essenceLabel.Position = UDim2.new(0, 10, 0, 40)
+    essenceLabel.BackgroundTransparency = 0.5
+    essenceLabel.TextXAlignment = Enum.TextXAlignment.Left
+    essenceLabel.Parent = gui
+
+    self.gui = gui
+    self.player = player
+    self.coinsLabel = coinsLabel
+    self.essenceLabel = essenceLabel
+
+    self:_update()
+    player:GetAttributeChangedSignal("Coins"):Connect(function()
+        self:_update()
+    end)
+    player:GetAttributeChangedSignal("Essence"):Connect(function()
+        self:_update()
+    end)
+
+    return self
+end
+
+function CurrencyDisplay:_update()
+    local coins = self.player:GetAttribute("Coins") or 0
+    local essence = self.player:GetAttribute("Essence") or 0
+    self.coinsLabel.Text = "Coins: " .. coins
+    self.essenceLabel.Text = "Essence: " .. essence
+end
+
+function CurrencyDisplay:Destroy()
+    if self.gui then
+        self.gui:Destroy()
+        self.gui = nil
+    end
+end
+
+return CurrencyDisplay
+


### PR DESCRIPTION
## Summary
- track match rewards with coin and essence payouts
- add survivor and shadow cosmetic unlock manager
- display player currency and cosmetic loadouts via UI

## Testing
- `luac -p Systems/RewardsManager.lua Systems/CosmeticsManager.lua UI/CurrencyDisplay.lua UI/CosmeticLoadout.lua Game/MatchController.lua && echo 'luac_success'`


------
https://chatgpt.com/codex/tasks/task_e_68a65f7da758832fa0f4dc9af0d86403