### PR TITLE
Add map vote UI, shadow roll, and cosmetic loadouts

### DIFF
--- a/Systems/MapVoteService.lua
+++ b/Systems/MapVoteService.lua
@@ -1,0 +1,86 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local MapVoteService = {}
+MapVoteService.__index = MapVoteService
+
+local maps = {
+    "SteelhideDepot",
+    "BlackpineReserve",
+    "StVerityWing",
+    "HarborlineDistrict",
+}
+
+local function find(tbl, val)
+    for i, v in ipairs(tbl) do
+        if v == val then
+            return i
+        end
+    end
+    return nil
+end
+
+function MapVoteService.new()
+    local self = setmetatable({}, MapVoteService)
+    self.votes = {}
+    self.maps = maps
+
+    local folder = ReplicatedStorage:FindFirstChild("MapVoteRemotes")
+    if not folder then
+        folder = Instance.new("Folder")
+        folder.Name = "MapVoteRemotes"
+        folder.Parent = ReplicatedStorage
+    end
+
+    self.voteEvent = folder:FindFirstChild("VoteMap")
+    if not self.voteEvent then
+        self.voteEvent = Instance.new("RemoteEvent")
+        self.voteEvent.Name = "VoteMap"
+        self.voteEvent.Parent = folder
+    end
+
+    self.resultEvent = folder:FindFirstChild("MapVoteResult")
+    if not self.resultEvent then
+        self.resultEvent = Instance.new("RemoteEvent")
+        self.resultEvent.Name = "MapVoteResult"
+        self.resultEvent.Parent = folder
+    end
+
+    self.voteEvent.OnServerEvent:Connect(function(player, map)
+        if find(self.maps, map) then
+            self.votes[player] = map
+        end
+    end)
+
+    Players.PlayerRemoving:Connect(function(plr)
+        self.votes[plr] = nil
+    end)
+
+    return self
+end
+
+function MapVoteService:Start(duration, callback)
+    self.votes = {}
+    self.voteEvent:FireAllClients(self.maps, duration)
+    task.delay(duration, function()
+        local counts = {}
+        for _, map in ipairs(self.maps) do
+            counts[map] = 0
+        end
+        for _, map in pairs(self.votes) do
+            counts[map] = counts[map] + 1
+        end
+        local winner = self.maps[1]
+        for map, count in pairs(counts) do
+            if count > counts[winner] then
+                winner = map
+            end
+        end
+        self.resultEvent:FireAllClients(winner, counts)
+        if callback then
+            callback(winner, counts)
+        end
+    end)
+end
+
+return MapVoteService

--- a/UI/CosmeticLoadout.lua
+++ b/UI/CosmeticLoadout.lua
@@ -3,43 +3,59 @@ local Players = game:GetService("Players")
 local CosmeticLoadout = {}
 CosmeticLoadout.__index = CosmeticLoadout
 
-function CosmeticLoadout.new(manager, role)
+function CosmeticLoadout.new(manager)
     local self = setmetatable({}, CosmeticLoadout)
     local player = Players.LocalPlayer
+
     local gui = Instance.new("ScreenGui")
     gui.Name = "CosmeticLoadout"
     gui.ResetOnSpawn = false
     gui.Parent = player:WaitForChild("PlayerGui")
 
-    local frame = Instance.new("Frame")
-    frame.Name = "CosmeticFrame"
-    frame.Size = UDim2.fromOffset(200, 200)
-    frame.Position = UDim2.new(1, -210, 0, 10)
-    frame.BackgroundTransparency = 0.5
-    frame.Parent = gui
+    local container = Instance.new("Frame")
+    container.Name = "CosmeticContainer"
+    container.Size = UDim2.fromOffset(420, 220)
+    container.Position = UDim2.new(1, -430, 0, 10)
+    container.BackgroundTransparency = 0.5
+    container.Parent = gui
 
     self.gui = gui
-    self.frame = frame
+    self.container = container
     self.player = player
     self.manager = manager
-    self.role = role
 
     self:Refresh()
     return self
 end
 
 function CosmeticLoadout:Refresh()
-    self.frame:ClearAllChildren()
-    local cosmetics = self.manager:GetOwned(self.player, self.role)
-    for i, name in ipairs(cosmetics) do
-        local button = Instance.new("TextButton")
-        button.Size = UDim2.fromOffset(180, 24)
-        button.Position = UDim2.new(0, 10, 0, (i - 1) * 26)
-        button.Text = name
-        button.Parent = self.frame
-        button.MouseButton1Click:Connect(function()
-            self.manager:Equip(self.player, self.role, name)
-        end)
+    self.container:ClearAllChildren()
+    local roles = {"Survivor", "Shadow"}
+    for rIndex, role in ipairs(roles) do
+        local frame = Instance.new("Frame")
+        frame.Size = UDim2.fromOffset(200, 200)
+        frame.Position = UDim2.new(0, (rIndex - 1) * 210, 0, 10)
+        frame.BackgroundTransparency = 0.3
+        frame.Parent = self.container
+
+        local label = Instance.new("TextLabel")
+        label.Size = UDim2.fromOffset(180, 24)
+        label.Position = UDim2.new(0, 10, 0, 0)
+        label.BackgroundTransparency = 1
+        label.Text = role
+        label.Parent = frame
+
+        local cosmetics = self.manager:GetOwned(self.player, role)
+        for i, name in ipairs(cosmetics) do
+            local button = Instance.new("TextButton")
+            button.Size = UDim2.fromOffset(180, 24)
+            button.Position = UDim2.new(0, 10, 0, i * 26)
+            button.Text = name
+            button.Parent = frame
+            button.MouseButton1Click:Connect(function()
+                self.manager:Equip(self.player, role, name)
+            end)
+        end
     end
 end
 
@@ -51,4 +67,3 @@ function CosmeticLoadout:Destroy()
 end
 
 return CosmeticLoadout
-

--- a/UI/MapVote.lua
+++ b/UI/MapVote.lua
@@ -1,0 +1,79 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local MapVote = {}
+MapVote.__index = MapVote
+
+function MapVote.new()
+    local self = setmetatable({}, MapVote)
+    local player = Players.LocalPlayer
+    local gui = Instance.new("ScreenGui")
+    gui.Name = "MapVote"
+    gui.ResetOnSpawn = false
+    gui.Parent = player:WaitForChild("PlayerGui")
+
+    local frame = Instance.new("Frame")
+    frame.Name = "VoteFrame"
+    frame.Size = UDim2.fromOffset(250, 150)
+    frame.Position = UDim2.new(0.5, -125, 0.5, -75)
+    frame.BackgroundTransparency = 0.5
+    frame.Parent = gui
+
+    self.gui = gui
+    self.frame = frame
+
+    local folder = ReplicatedStorage:WaitForChild("MapVoteRemotes")
+    self.voteEvent = folder:WaitForChild("VoteMap")
+    self.resultEvent = folder:WaitForChild("MapVoteResult")
+
+    self.voteEvent.OnClientEvent:Connect(function(maps)
+        self:ShowOptions(maps)
+    end)
+
+    self.resultEvent.OnClientEvent:Connect(function(winner, counts)
+        self:ShowResults(winner, counts)
+    end)
+
+    return self
+end
+
+function MapVote:ShowOptions(maps)
+    self.frame:ClearAllChildren()
+    for i, map in ipairs(maps) do
+        local button = Instance.new("TextButton")
+        button.Size = UDim2.fromOffset(220, 24)
+        button.Position = UDim2.new(0, 15, 0, (i - 1) * 26 + 10)
+        button.Text = map
+        button.Parent = self.frame
+        button.MouseButton1Click:Connect(function()
+            self.voteEvent:FireServer(map)
+        end)
+    end
+end
+
+function MapVote:ShowResults(winner, counts)
+    self.frame:ClearAllChildren()
+    local i = 0
+    for map, count in pairs(counts) do
+        local label = Instance.new("TextLabel")
+        label.Size = UDim2.fromOffset(220, 24)
+        label.Position = UDim2.new(0, 15, 0, i * 26 + 10)
+        label.BackgroundTransparency = 0.5
+        label.Text = map .. ": " .. count
+        if map == winner then
+            label.BackgroundColor3 = Color3.fromRGB(0, 255, 0)
+            label.BackgroundTransparency = 0
+        end
+        label.Parent = self.frame
+        i = i + 1
+    end
+end
+
+function MapVote:Destroy()
+    if self.gui then
+        self.gui:Destroy()
+        self.gui = nil
+    end
+end
+
+return MapVote


### PR DESCRIPTION
## Summary
- implement server/client map voting with highlighted results
- add random Shadow selection roll in match controller
- provide cosmetic loadout screen showing Survivor and Shadow cosmetics

## Testing
- `luac -p Game/MatchController.lua Systems/MapVoteService.lua UI/MapVote.lua UI/CosmeticLoadout.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a66f9724d0832fbccd8f9574530267