### PR TITLE
Add ambient loops and environmental SFX

### DIFF
--- a/Assets/SFX/asylum_hum_loop.wav
+++ b/Assets/SFX/asylum_hum_loop.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a63be9269b6d0b92ea1e6c1f34a695f557b654b0d1f93b1dea7e75a1350188f7
+size 264644

--- a/Assets/SFX/campfire_crackle_loop.wav
+++ b/Assets/SFX/campfire_crackle_loop.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72dd764107919d928228c9ebfa97560d2fdae5193b62308b6fa6b66dac9bad01
+size 264644

--- a/Assets/SFX/door_creak.wav
+++ b/Assets/SFX/door_creak.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:197207f27bc3ee8cf9d00b873ae028fe8e62ff16baceec7647c1cb0fb2f968c1
+size 88244

--- a/Assets/SFX/forest_wind_loop.wav
+++ b/Assets/SFX/forest_wind_loop.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa1cd47fab57e292073ba5c87ac4d464b0c88d7e17ef410cd79968d28dbae286
+size 352844

--- a/Assets/SFX/generate_sfx.py
+++ b/Assets/SFX/generate_sfx.py
@@ -138,17 +138,98 @@ def metal_creak():
         samples.append((math.sin(2 * math.pi * 30 * t) + noise) * env * 0.4)
     return samples
 
-write_wave('Assets/SFX/footstep.wav', footstep_loop())
-write_wave('Assets/SFX/sprint_breathing.wav', breathing_loop())
-write_wave('Assets/SFX/flashlight_flicker.wav', flashlight_flicker())
-write_wave('Assets/SFX/heartbeat_slow.wav', heartbeat_loop(60))
-write_wave('Assets/SFX/heartbeat_fast.wav', heartbeat_loop(120))
-write_wave('Assets/SFX/push_grunt.wav', push_grunt())
-write_wave('Assets/SFX/push_impact.wav', push_impact())
-write_wave('Assets/SFX/whisper_loop.wav', whisper_loop())
-write_wave('Assets/SFX/phase_dash.wav', phase_dash_echo())
-write_wave('Assets/SFX/dark_surge.wav', dark_surge_blackout())
-write_wave('Assets/SFX/tag_impact.wav', tag_impact())
-write_wave('Assets/SFX/infection_transform.wav', infection_transform())
-write_wave('Assets/SFX/ambient_hum.wav', ambient_hum())
-write_wave('Assets/SFX/creaking_metal.wav', metal_creak())
+def machinery_loop():
+    dur = 3.0
+    n = int(SAMPLE_RATE * dur)
+    samples = []
+    clank_interval = int(SAMPLE_RATE * 0.75)
+    for i in range(n):
+        t = i / SAMPLE_RATE
+        hum = math.sin(2 * math.pi * 40 * t) * 0.1 + math.sin(2 * math.pi * 80 * t) * 0.05
+        clank = 0.0
+        pos = i % clank_interval
+        if pos < int(SAMPLE_RATE * 0.05):
+            env = math.exp(-40 * pos / SAMPLE_RATE)
+            clank = math.sin(2 * math.pi * 200 * pos / SAMPLE_RATE) * env * 0.3
+        samples.append(hum + clank)
+    return samples
+
+def forest_wind_loop():
+    dur = 4.0
+    n = int(SAMPLE_RATE * dur)
+    samples = []
+    prev = 0.0
+    for i in range(n):
+        t = i / SAMPLE_RATE
+        noise = random.uniform(-1, 1)
+        prev = 0.98 * prev + 0.02 * noise
+        gust = 0.5 + 0.5 * math.sin(2 * math.pi * 0.25 * t)
+        howl = math.sin(2 * math.pi * 200 * t) * max(0.0, math.sin(2 * math.pi * 0.25 * t))**2
+        samples.append(prev * gust * 0.3 + howl * 0.1)
+    return samples
+
+def asylum_hum_loop():
+    dur = 3.0
+    n = int(SAMPLE_RATE * dur)
+    samples = []
+    for i in range(n):
+        t = i / SAMPLE_RATE
+        base = math.sin(2 * math.pi * 55 * t) + 0.5 * math.sin(2 * math.pi * 110 * t)
+        mod = math.sin(2 * math.pi * 2 * t) * 0.02
+        samples.append((base * 0.08) + mod)
+    return samples
+
+def door_creak():
+    dur = 1.0
+    n = int(SAMPLE_RATE * dur)
+    samples = []
+    for i in range(n):
+        t = i / SAMPLE_RATE
+        freq = 80 + 120 * t
+        env = math.sin(math.pi * t / dur)
+        noise = random.uniform(-0.3, 0.3)
+        samples.append((math.sin(2 * math.pi * freq * t) + noise) * env * 0.5)
+    return samples
+
+def switch_click():
+    n = int(SAMPLE_RATE * 0.1)
+    return [math.sin(2 * math.pi * 2000 * (i / SAMPLE_RATE)) * math.exp(-60 * i / SAMPLE_RATE) * 0.5 for i in range(n)]
+
+def campfire_crackle_loop():
+    dur = 3.0
+    n = int(SAMPLE_RATE * dur)
+    samples = [random.uniform(-0.02, 0.02) for _ in range(n)]
+    step = int(SAMPLE_RATE * 0.1)
+    burst = int(SAMPLE_RATE * 0.02)
+    for start in range(0, n, step):
+        for j in range(burst):
+            idx = start + j
+            if idx < n:
+                env = math.exp(-50 * j / SAMPLE_RATE)
+                samples[idx] += random.uniform(-1, 1) * env * 0.3
+    return samples
+
+def ensure_wave(path, gen):
+    if not os.path.exists(path):
+        write_wave(path, gen())
+
+ensure_wave('Assets/SFX/footstep.wav', footstep_loop)
+ensure_wave('Assets/SFX/sprint_breathing.wav', breathing_loop)
+ensure_wave('Assets/SFX/flashlight_flicker.wav', flashlight_flicker)
+ensure_wave('Assets/SFX/heartbeat_slow.wav', lambda: heartbeat_loop(60))
+ensure_wave('Assets/SFX/heartbeat_fast.wav', lambda: heartbeat_loop(120))
+ensure_wave('Assets/SFX/push_grunt.wav', push_grunt)
+ensure_wave('Assets/SFX/push_impact.wav', push_impact)
+ensure_wave('Assets/SFX/whisper_loop.wav', whisper_loop)
+ensure_wave('Assets/SFX/phase_dash.wav', phase_dash_echo)
+ensure_wave('Assets/SFX/dark_surge.wav', dark_surge_blackout)
+ensure_wave('Assets/SFX/tag_impact.wav', tag_impact)
+ensure_wave('Assets/SFX/infection_transform.wav', infection_transform)
+ensure_wave('Assets/SFX/ambient_hum.wav', ambient_hum)
+ensure_wave('Assets/SFX/creaking_metal.wav', metal_creak)
+ensure_wave('Assets/SFX/warehouse_machinery_loop.wav', machinery_loop)
+ensure_wave('Assets/SFX/forest_wind_loop.wav', forest_wind_loop)
+ensure_wave('Assets/SFX/asylum_hum_loop.wav', asylum_hum_loop)
+ensure_wave('Assets/SFX/door_creak.wav', door_creak)
+ensure_wave('Assets/SFX/switch_click.wav', switch_click)
+ensure_wave('Assets/SFX/campfire_crackle_loop.wav', campfire_crackle_loop)

--- a/Assets/SFX/switch_click.wav
+++ b/Assets/SFX/switch_click.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe1c229850499f5217c340a3581b7013777a06ad5c933808e87c62bf2369db95
+size 8864

--- a/Assets/SFX/warehouse_machinery_loop.wav
+++ b/Assets/SFX/warehouse_machinery_loop.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b709adf4a063d71f062b7a9b0bc1135176a68fd021aecb94220bf89e09de8ce7
+size 264644

--- a/Players/Survivor/UseComponent.lua
+++ b/Players/Survivor/UseComponent.lua
@@ -57,12 +57,20 @@ function UseComponent:useDoor(part)
         local target = hinge.TargetAngle == 0 and 90 or 0
         hinge.TargetAngle = target
     end
+    local sound = part:FindFirstChildWhichIsA("Sound")
+    if sound then
+        sound:Play()
+    end
 end
 
 function UseComponent:useSwitch(part)
     local event = part:FindFirstChildWhichIsA("BindableEvent")
     if event then
         event:Fire()
+    end
+    local sound = part:FindFirstChildWhichIsA("Sound")
+    if sound then
+        sound:Play()
     end
 end
 

--- a/World/BlackpineReserve.lua
+++ b/World/BlackpineReserve.lua
@@ -146,7 +146,7 @@ function Map:_createCampfire(position)
     light.Parent = base
 
     local sound = Instance.new("Sound")
-    sound.SoundId = "rbxassetid://0"
+    sound.SoundId = "rbxasset://sounds/campfire_crackle_loop.wav"
     sound.Looped = true
     sound.Volume = 0.4
     sound.Playing = true
@@ -178,7 +178,7 @@ function Map:_createWind(position)
     self:_addPart(part)
 
     local sound = Instance.new("Sound")
-    sound.SoundId = "rbxassetid://0"
+    sound.SoundId = "rbxasset://sounds/forest_wind_loop.wav"
     sound.Looped = true
     sound.Volume = 0.3
     sound.Playing = true

--- a/World/StVerityWing.lua
+++ b/World/StVerityWing.lua
@@ -79,11 +79,15 @@ function Map:_createWingLights(positions, switchPos)
     local event = Instance.new("BindableEvent")
     event.Parent = switch
     local on = false
+    local sound = Instance.new("Sound")
+    sound.SoundId = "rbxasset://sounds/switch_click.wav"
+    sound.Parent = switch
     event.Event:Connect(function()
         on = not on
         for _, l in ipairs(lights) do
             l.Enabled = on
         end
+        sound:Play()
     end)
 end
 
@@ -126,6 +130,10 @@ function Map:_createLockedDoor(cframe, size, keyId)
     hinge.TargetAngle = 0
     hinge.AngularSpeed = 2
     hinge.Parent = door
+
+    local sound = Instance.new("Sound")
+    sound.SoundId = "rbxasset://sounds/door_creak.wav"
+    sound.Parent = door
 end
 
 function Map:_createAudioZone(position, soundId, volume)
@@ -175,8 +183,8 @@ function Map:Build()
     self:_createLockedDoor(CFrame.new(0,5,30), Vector3.new(6,10,1), "Main")
 
     -- audio zones
-    self:_createAudioZone(Vector3.new(0,5,0), "rbxassetid://0", 0.2)
-    self:_createAudioZone(Vector3.new(0,15,0), "rbxassetid://0", 0.3)
+    self:_createAudioZone(Vector3.new(0,5,0), "rbxasset://sounds/asylum_hum_loop.wav", 0.2)
+    self:_createAudioZone(Vector3.new(0,15,0), "rbxasset://sounds/asylum_hum_loop.wav", 0.3)
 
     assert(self.partCount <= Map.MAX_PARTS, string.format("part budget exceeded (%d > %d)", self.partCount, Map.MAX_PARTS))
     return self.model

--- a/World/SteelhideDepot.lua
+++ b/World/SteelhideDepot.lua
@@ -46,8 +46,12 @@ function Map:_createSwitchLight(position)
 
     local click = Instance.new("ClickDetector")
     click.Parent = lightPart
+    local sound = Instance.new("Sound")
+    sound.SoundId = "rbxasset://sounds/switch_click.wav"
+    sound.Parent = lightPart
     click.MouseClick:Connect(function()
         light.Enabled = not light.Enabled
+        sound:Play()
     end)
 end
 
@@ -92,7 +96,7 @@ function Map:_createAmbientSound(position)
     self:_addPart(emitter)
 
     local sound = Instance.new("Sound")
-    sound.SoundId = "rbxassetid://0"
+    sound.SoundId = "rbxasset://sounds/warehouse_machinery_loop.wav"
     sound.Looped = true
     sound.Volume = 0.4
     sound.Playing = true


### PR DESCRIPTION
## Summary
- generate warehouse machinery, forest wind, asylum hum loops plus door, switch, and campfire SFX
- play door and switch sounds on interaction
- hook new ambient loops into maps

## Testing
- `python -m py_compile Assets/SFX/generate_sfx.py`
- `python Assets/SFX/generate_sfx.py`
- `luac -p Players/Survivor/UseComponent.lua World/StVerityWing.lua World/SteelhideDepot.lua World/BlackpineReserve.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a6723fc7dc832fbb09d0e745b1f5bf