### PR TITLE
Add server match orchestration scripts

### DIFF
--- a/ServerScriptService/Darkness.server.lua
+++ b/ServerScriptService/Darkness.server.lua
@@ -1,0 +1,33 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local Darkness = {}
+Darkness.__index = Darkness
+
+function Darkness.new()
+    local self = setmetatable({}, Darkness)
+    self.coverage = 0
+    self.nodes = 0
+    self.event = Instance.new("BindableEvent")
+    self.event.Name = "DarknessUpdate"
+    self.event.Parent = ReplicatedStorage
+    return self
+end
+
+function Darkness:Start()
+    local GameDef = require(ReplicatedStorage.Shared.GameDef)
+    self.coverage = 0
+    self.nodes = 0
+    for _, step in ipairs(GameDef.Darkness.Expansion) do
+        task.delay(step.t, function()
+            if step.expand then
+                self.coverage = math.min(GameDef.Darkness.MaxCoverage, self.coverage + step.expand)
+            end
+            if step.activateNodes then
+                self.nodes = self.nodes + step.activateNodes
+            end
+            self.event:Fire(self.coverage, self.nodes)
+        end)
+    end
+end
+
+return Darkness

--- a/ServerScriptService/Economy.server.lua
+++ b/ServerScriptService/Economy.server.lua
@@ -1,0 +1,40 @@
+local RewardsManager = require(game:GetService("ServerScriptService").Parent.Systems.RewardsManager)
+
+local Economy = {}
+Economy.__index = Economy
+
+function Economy.new()
+    local self = setmetatable({}, Economy)
+    self.manager = RewardsManager.new()
+    return self
+end
+
+function Economy:BeginMatch(roles)
+    self.manager:BeginMatch(roles)
+end
+
+function Economy:RecordTag(plr, isMulti, isAmbush)
+    self.manager:RecordTag(plr, isMulti, isAmbush)
+end
+
+function Economy:RecordAssist(plr)
+    self.manager:RecordAssist(plr)
+end
+
+function Economy:RecordEscape(plr)
+    self.manager:RecordEscape(plr)
+end
+
+function Economy:RecordElimination(plr)
+    self.manager:RecordElimination(plr)
+end
+
+function Economy:RecordWipe(plr)
+    self.manager:RecordWipe(plr)
+end
+
+function Economy:Distribute(winningTeam)
+    self.manager:Distribute(winningTeam)
+end
+
+return Economy

--- a/ServerScriptService/Interact.server.lua
+++ b/ServerScriptService/Interact.server.lua
@@ -1,0 +1,50 @@
+local CollectionService = game:GetService("CollectionService")
+
+local Interact = {}
+Interact.__index = Interact
+
+function Interact.new()
+    local self = setmetatable({}, Interact)
+    self:_initTagged()
+    return self
+end
+
+function Interact:_hookPrompt(inst, handler)
+    local prompt = inst:FindFirstChildWhichIsA("ProximityPrompt")
+    if prompt then
+        prompt.Triggered:Connect(function(plr)
+            handler(self, plr, inst)
+        end)
+    end
+end
+
+function Interact:_initTagged()
+    for _, station in ipairs(CollectionService:GetTagged("RechargeStation")) do
+        self:_hookPrompt(station, self._recharge)
+    end
+    for _, door in ipairs(CollectionService:GetTagged("Door")) do
+        self:_hookPrompt(door, self._openDoor)
+    end
+end
+
+function Interact:_recharge(plr, station)
+    local char = plr.Character
+    if not char then return end
+    local tool = char:FindFirstChild("Flashlight")
+    if tool then
+        tool:SetAttribute("Battery", 100)
+    end
+end
+
+function Interact:_openDoor(plr, door)
+    if door:GetAttribute("Open") then return end
+    door:SetAttribute("Open", true)
+    local hinge = door:FindFirstChild("Hinge")
+    if hinge then
+        hinge.C0 = hinge.C0 * CFrame.Angles(0, math.rad(90), 0)
+    else
+        door:PivotTo(door.CFrame * CFrame.Angles(0, math.rad(90), 0))
+    end
+end
+
+return Interact

--- a/ServerScriptService/Match.server.lua
+++ b/ServerScriptService/Match.server.lua
@@ -1,0 +1,112 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local GameDef = require(ReplicatedStorage.Shared.GameDef)
+
+local Match = {}
+Match.__index = Match
+
+local function cloneArray(arr)
+    local t = {}
+    for i, v in ipairs(arr) do
+        t[i] = v
+    end
+    return t
+end
+
+function Match.new(deps)
+    local self = setmetatable({}, Match)
+    self.darkness = deps.darkness
+    self.spawns = deps.spawns
+    self.economy = deps.economy
+    self.tagging = nil
+    self.interact = nil
+    self.phase = "Lobby"
+    self.roles = {}
+    return self
+end
+
+function Match:SetTagging(tagging)
+    self.tagging = tagging
+end
+
+function Match:SetInteract(interact)
+    self.interact = interact
+end
+
+function Match:Start()
+    self:Lobby()
+end
+
+function Match:Lobby()
+    task.delay(15, function()
+        if #Players:GetPlayers() > 0 then
+            self:Prep()
+        else
+            self:Lobby()
+        end
+    end)
+end
+
+function Match:_assignRoles()
+    local players = Players:GetPlayers()
+    local pool = cloneArray(players)
+    local shadows = math.max(1, math.floor(#players / 5))
+    for i = 1, shadows do
+        local idx = math.random(1, #pool)
+        local plr = table.remove(pool, idx)
+        self.roles[plr] = "Shadow"
+    end
+    for _, plr in ipairs(pool) do
+        self.roles[plr] = "Survivor"
+    end
+end
+
+function Match:Prep()
+    self.phase = "Prep"
+    self:_assignRoles()
+    self.economy:BeginMatch(self.roles)
+    for plr, role in pairs(self.roles) do
+        self.spawns:Spawn(plr, role)
+    end
+    self.darkness:Start()
+    task.delay(GameDef.Match.PrepTime, function()
+        self:Hunt()
+    end)
+end
+
+function Match:Hunt()
+    self.phase = "Hunt"
+    task.delay(GameDef.Match.HuntMax, function()
+        self:Endgame()
+    end)
+end
+
+function Match:Endgame()
+    self.phase = "Endgame"
+    task.delay(GameDef.Match.Endgame, function()
+        self:Results()
+    end)
+end
+
+function Match:Results()
+    self.phase = "Results"
+    local winner = self:WinningTeam()
+    self.economy:Distribute(winner)
+    task.delay(10, function()
+        self.roles = {}
+        self:Lobby()
+    end)
+end
+
+function Match:WinningTeam()
+    local alive = 0
+    for plr, role in pairs(self.roles) do
+        if role == "Survivor" and plr.Parent then
+            alive = alive + 1
+        end
+    end
+    return alive > 0 and "Survivors" or "Shadows"
+end
+
+return Match

--- a/ServerScriptService/Save.server.lua
+++ b/ServerScriptService/Save.server.lua
@@ -1,0 +1,56 @@
+local Players = game:GetService("Players")
+local DataStoreService = game:GetService("DataStoreService")
+
+local Save = {}
+Save.__index = Save
+
+local STORE = DataStoreService:GetDataStore("ShadowTagPlayerData")
+local RETRIES = 5
+
+local function retry(promise)
+    local lastErr
+    for i = 1, RETRIES do
+        local ok, result = pcall(promise)
+        if ok then
+            return result
+        end
+        lastErr = result
+        task.wait(2 ^ i)
+    end
+    warn("DataStore failure: " .. tostring(lastErr))
+    return nil
+end
+
+function Save.load(plr)
+    local key = "p_" .. plr.UserId
+    local data = retry(function()
+        return STORE:GetAsync(key)
+    end) or {}
+    plr:SetAttribute("Coins", data.Coins or 0)
+    plr:SetAttribute("Essence", data.Essence or 0)
+    plr:SetAttribute("Cosmetics", data.Cosmetics or {})
+end
+
+function Save.save(plr)
+    local key = "p_" .. plr.UserId
+    local data = {
+        Coins = plr:GetAttribute("Coins"),
+        Essence = plr:GetAttribute("Essence"),
+        Cosmetics = plr:GetAttribute("Cosmetics"),
+    }
+    retry(function()
+        STORE:SetAsync(key, data)
+    end)
+end
+
+function Save.init()
+    Players.PlayerAdded:Connect(Save.load)
+    Players.PlayerRemoving:Connect(Save.save)
+    game:BindToClose(function()
+        for _, plr in ipairs(Players:GetPlayers()) do
+            Save.save(plr)
+        end
+    end)
+end
+
+return Save

--- a/ServerScriptService/Spawns.server.lua
+++ b/ServerScriptService/Spawns.server.lua
@@ -1,0 +1,32 @@
+local Spawns = {}
+Spawns.__index = Spawns
+
+function Spawns.new()
+    local self = setmetatable({}, Spawns)
+    local root = workspace:WaitForChild("Spawns")
+    self.survivorFolder = root:WaitForChild("Survivor")
+    self.shadowFolder = root:WaitForChild("Shadow")
+    return self
+end
+
+local function choose(folder)
+    local children = folder:GetChildren()
+    if #children == 0 then
+        return nil
+    end
+    return children[math.random(1, #children)]
+end
+
+function Spawns:Spawn(plr, role)
+    local folder = role == "Shadow" and self.shadowFolder or self.survivorFolder
+    local point = choose(folder)
+    if not point then return end
+    plr:LoadCharacter()
+    local char = plr.Character
+    if not char then return end
+    local cf = point.CFrame + Vector3.new(0, 3, 0)
+    char:PivotTo(cf)
+    plr:SetAttribute("Role", role)
+end
+
+return Spawns

--- a/ServerScriptService/SrvInit.server.lua
+++ b/ServerScriptService/SrvInit.server.lua
@@ -1,0 +1,34 @@
+local Players = game:GetService("Players")
+
+local Match = require(script.Match)
+local Darkness = require(script.Darkness)
+local Spawns = require(script.Spawns)
+local Interact = require(script.Interact)
+local Tagging = require(script.Tagging)
+local Economy = require(script.Economy)
+local Save = require(script.Save)
+
+local darkness = Darkness.new()
+local spawns = Spawns.new()
+local economy = Economy.new()
+local match = Match.new({
+    darkness = darkness,
+    spawns = spawns,
+    economy = economy,
+})
+local tagging = Tagging.new(match, spawns, economy)
+match:SetTagging(tagging)
+local interact = Interact.new()
+match:SetInteract(interact)
+
+Save.init()
+
+Players.PlayerAdded:Connect(function(plr)
+    Save.load(plr)
+end)
+
+Players.PlayerRemoving:Connect(function(plr)
+    Save.save(plr)
+end)
+
+match:Start()

--- a/ServerScriptService/Tagging.server.lua
+++ b/ServerScriptService/Tagging.server.lua
@@ -1,0 +1,26 @@
+local Players = game:GetService("Players")
+
+local Tagging = {}
+Tagging.__index = Tagging
+
+function Tagging.new(match, spawns, economy)
+    local self = setmetatable({}, Tagging)
+    self.match = match
+    self.spawns = spawns
+    self.economy = economy
+    return self
+end
+
+function Tagging:Tag(shadow, target, isAmbush)
+    if self.match.roles[target] ~= "Survivor" then
+        return
+    end
+    self.match.roles[target] = "Shadow"
+    self.economy:RecordTag(shadow, false, isAmbush)
+    target:SetAttribute("Role", "Shadow")
+    task.delay(3, function()
+        self.spawns:Spawn(target, "Shadow")
+    end)
+end
+
+return Tagging


### PR DESCRIPTION
## Summary
- add `SrvInit.server.lua` to bootstrap server systems
- add match, darkness, spawn, interaction, tagging, economy, and save scripts

## Testing
- `luac -p ServerScriptService/SrvInit.server.lua ServerScriptService/Match.server.lua ServerScriptService/Darkness.server.lua ServerScriptService/Spawns.server.lua ServerScriptService/Interact.server.lua ServerScriptService/Tagging.server.lua ServerScriptService/Economy.server.lua ServerScriptService/Save.server.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a67a2575dc832fbeb1506e9a2556a6