### PR TITLE
Add StarterGui UI screens

### DIFF
--- a/StarterGui/HUD.gui
+++ b/StarterGui/HUD.gui
@@ -1,0 +1,75 @@
+<roblox version="4">
+  <Item class="ScreenGui" name="HUD">
+    <Properties>
+      <bool name="ResetOnSpawn">false</bool>
+      <bool name="IgnoreGuiInset">true</bool>
+      <string name="Name">HUD</string>
+    </Properties>
+    <Item class="Frame" name="SafeArea">
+      <Properties>
+        <bool name="BackgroundTransparency">1</bool>
+        <Vector2 name="AnchorPoint">
+          <X>0.5</X>
+          <Y>0.5</Y>
+        </Vector2>
+        <UDim2 name="Position">
+          <XScale>0.5</XScale>
+          <XOffset>0</XOffset>
+          <YScale>0.5</YScale>
+          <YOffset>0</YOffset>
+        </UDim2>
+        <UDim2 name="Size">
+          <XScale>0.9</XScale>
+          <XOffset>0</XOffset>
+          <YScale>0.9</YScale>
+          <YOffset>0</YOffset>
+        </UDim2>
+        <bool name="SelectionGroup">true</bool>
+      </Properties>
+      <Item class="TextLabel" name="HealthLabel">
+        <Properties>
+          <bool name="BackgroundTransparency">1</bool>
+          <UDim2 name="Position">
+            <XScale>0</XScale>
+            <XOffset>10</XOffset>
+            <YScale>0</YScale>
+            <YOffset>10</YOffset>
+          </UDim2>
+          <UDim2 name="Size">
+            <XScale>0</XScale>
+            <XOffset>200</XOffset>
+            <YScale>0</YScale>
+            <YOffset>40</YOffset>
+          </UDim2>
+          <Enum name="Font">GothamBold</Enum>
+          <bool name="TextScaled">true</bool>
+          <string name="Text">Health: 100</string>
+          <Color3 name="TextColor3">1 1 1</Color3>
+          <string name="AccessibleDescription">Displays current health.</string>
+        </Properties>
+      </Item>
+      <Item class="TextLabel" name="StaminaLabel">
+        <Properties>
+          <bool name="BackgroundTransparency">1</bool>
+          <UDim2 name="Position">
+            <XScale>0</XScale>
+            <XOffset>10</XOffset>
+            <YScale>0</YScale>
+            <YOffset>60</YOffset>
+          </UDim2>
+          <UDim2 name="Size">
+            <XScale>0</XScale>
+            <XOffset>200</XOffset>
+            <YScale>0</YScale>
+            <YOffset>40</YOffset>
+          </UDim2>
+          <Enum name="Font">GothamBold</Enum>
+          <bool name="TextScaled">true</bool>
+          <string name="Text">Stamina: 100</string>
+          <Color3 name="TextColor3">1 1 1</Color3>
+          <string name="AccessibleDescription">Displays current stamina.</string>
+        </Properties>
+      </Item>
+    </Item>
+  </Item>
+</roblox>

--- a/StarterGui/Menus.gui
+++ b/StarterGui/Menus.gui
@@ -1,0 +1,73 @@
+<roblox version="4">
+  <Item class="ScreenGui" name="Menus">
+    <Properties>
+      <bool name="ResetOnSpawn">false</bool>
+      <bool name="IgnoreGuiInset">true</bool>
+      <string name="Name">Menus</string>
+    </Properties>
+    <Item class="Frame" name="SafeArea">
+      <Properties>
+        <bool name="BackgroundTransparency">0.3</bool>
+        <Vector2 name="AnchorPoint">
+          <X>0.5</X>
+          <Y>0.5</Y>
+        </Vector2>
+        <UDim2 name="Position">
+          <XScale>0.5</XScale>
+          <XOffset>0</XOffset>
+          <YScale>0.5</YScale>
+          <YOffset>0</YOffset>
+        </UDim2>
+        <UDim2 name="Size">
+          <XScale>0.9</XScale>
+          <XOffset>0</XOffset>
+          <YScale>0.9</YScale>
+          <YOffset>0</YOffset>
+        </UDim2>
+        <bool name="SelectionGroup">true</bool>
+      </Properties>
+      <Item class="UIListLayout" name="Layout">
+        <Properties>
+          <Enum name="FillDirection">Vertical</Enum>
+          <number name="Padding">10</number>
+        </Properties>
+      </Item>
+      <Item class="TextButton" name="PlayButton">
+        <Properties>
+          <bool name="AutoButtonColor">true</bool>
+          <bool name="BackgroundTransparency">0.2</bool>
+          <UDim2 name="Size">
+            <XScale>0</XScale>
+            <XOffset>300</XOffset>
+            <YScale>0</YScale>
+            <YOffset>80</YOffset>
+          </UDim2>
+          <Enum name="Font">GothamBold</Enum>
+          <bool name="TextScaled">true</bool>
+          <string name="Text">Play</string>
+          <Color3 name="TextColor3">1 1 1</Color3>
+          <bool name="Selectable">true</bool>
+          <string name="AccessibleDescription">Start the game.</string>
+        </Properties>
+      </Item>
+      <Item class="TextButton" name="SettingsButton">
+        <Properties>
+          <bool name="AutoButtonColor">true</bool>
+          <bool name="BackgroundTransparency">0.2</bool>
+          <UDim2 name="Size">
+            <XScale>0</XScale>
+            <XOffset>300</XOffset>
+            <YScale>0</YScale>
+            <YOffset>80</YOffset>
+          </UDim2>
+          <Enum name="Font">GothamBold</Enum>
+          <bool name="TextScaled">true</bool>
+          <string name="Text">Settings</string>
+          <Color3 name="TextColor3">1 1 1</Color3>
+          <bool name="Selectable">true</bool>
+          <string name="AccessibleDescription">Open settings menu.</string>
+        </Properties>
+      </Item>
+    </Item>
+  </Item>
+</roblox>

--- a/StarterGui/Results.gui
+++ b/StarterGui/Results.gui
@@ -1,0 +1,76 @@
+<roblox version="4">
+  <Item class="ScreenGui" name="Results">
+    <Properties>
+      <bool name="ResetOnSpawn">false</bool>
+      <bool name="IgnoreGuiInset">true</bool>
+      <string name="Name">Results</string>
+    </Properties>
+    <Item class="Frame" name="SafeArea">
+      <Properties>
+        <bool name="BackgroundTransparency">0.3</bool>
+        <Vector2 name="AnchorPoint">
+          <X>0.5</X>
+          <Y>0.5</Y>
+        </Vector2>
+        <UDim2 name="Position">
+          <XScale>0.5</XScale>
+          <XOffset>0</XOffset>
+          <YScale>0.5</YScale>
+          <YOffset>0</YOffset>
+        </UDim2>
+        <UDim2 name="Size">
+          <XScale>0.9</XScale>
+          <XOffset>0</XOffset>
+          <YScale>0.9</YScale>
+          <YOffset>0</YOffset>
+        </UDim2>
+        <bool name="SelectionGroup">true</bool>
+      </Properties>
+      <Item class="TextLabel" name="SummaryLabel">
+        <Properties>
+          <bool name="BackgroundTransparency">1</bool>
+          <UDim2 name="Position">
+            <XScale>0.5</XScale>
+            <XOffset>0</XOffset>
+            <YScale>0.2</YScale>
+            <YOffset>0</YOffset>
+          </UDim2>
+          <UDim2 name="Size">
+            <XScale>0.8</XScale>
+            <XOffset>0</XOffset>
+            <YScale>0.3</YScale>
+            <YOffset>0</YOffset>
+          </UDim2>
+          <Enum name="Font">GothamBold</Enum>
+          <bool name="TextScaled">true</bool>
+          <string name="Text">Results</string>
+          <Color3 name="TextColor3">1 1 1</Color3>
+          <string name="AccessibleDescription">Shows match summary.</string>
+        </Properties>
+      </Item>
+      <Item class="TextButton" name="ContinueButton">
+        <Properties>
+          <bool name="BackgroundTransparency">0.2</bool>
+          <UDim2 name="Position">
+            <XScale>0.5</XScale>
+            <XOffset>0</XOffset>
+            <YScale>0.8</YScale>
+            <YOffset>0</YOffset>
+          </UDim2>
+          <UDim2 name="Size">
+            <XScale>0</XScale>
+            <XOffset>300</XOffset>
+            <YScale>0</YScale>
+            <YOffset>80</YOffset>
+          </UDim2>
+          <Enum name="Font">GothamBold</Enum>
+          <bool name="TextScaled">true</bool>
+          <string name="Text">Continue</string>
+          <Color3 name="TextColor3">1 1 1</Color3>
+          <bool name="Selectable">true</bool>
+          <string name="AccessibleDescription">Proceed to next screen.</string>
+        </Properties>
+      </Item>
+    </Item>
+  </Item>
+</roblox>

--- a/StarterGui/Settings.gui
+++ b/StarterGui/Settings.gui
@@ -1,0 +1,105 @@
+<roblox version="4">
+  <Item class="ScreenGui" name="Settings">
+    <Properties>
+      <bool name="ResetOnSpawn">false</bool>
+      <bool name="IgnoreGuiInset">true</bool>
+      <string name="Name">Settings</string>
+    </Properties>
+    <Item class="Frame" name="SafeArea">
+      <Properties>
+        <bool name="BackgroundTransparency">0.3</bool>
+        <Vector2 name="AnchorPoint">
+          <X>0.5</X>
+          <Y>0.5</Y>
+        </Vector2>
+        <UDim2 name="Position">
+          <XScale>0.5</XScale>
+          <XOffset>0</XOffset>
+          <YScale>0.5</YScale>
+          <YOffset>0</YOffset>
+        </UDim2>
+        <UDim2 name="Size">
+          <XScale>0.9</XScale>
+          <XOffset>0</XOffset>
+          <YScale>0.9</YScale>
+          <YOffset>0</YOffset>
+        </UDim2>
+        <bool name="SelectionGroup">true</bool>
+      </Properties>
+      <Item class="UIListLayout" name="Layout">
+        <Properties>
+          <Enum name="FillDirection">Vertical</Enum>
+          <number name="Padding">10</number>
+        </Properties>
+      </Item>
+      <Item class="Frame" name="VolumeRow">
+        <Properties>
+          <bool name="BackgroundTransparency">1</bool>
+          <UDim2 name="Size">
+            <XScale>0</XScale>
+            <XOffset>400</XOffset>
+            <YScale>0</YScale>
+            <YOffset>80</YOffset>
+          </UDim2>
+          <bool name="SelectionGroup">true</bool>
+        </Properties>
+        <Item class="UIListLayout" name="RowLayout">
+          <Properties>
+            <Enum name="FillDirection">Horizontal</Enum>
+            <number name="Padding">10</number>
+          </Properties>
+        </Item>
+        <Item class="TextLabel" name="VolumeLabel">
+          <Properties>
+            <bool name="BackgroundTransparency">1</bool>
+            <UDim2 name="Size">
+              <XScale>0</XScale>
+              <XOffset>160</XOffset>
+              <YScale>0</YScale>
+              <YOffset>80</YOffset>
+            </UDim2>
+            <Enum name="Font">GothamBold</Enum>
+            <bool name="TextScaled">true</bool>
+            <string name="Text">Volume</string>
+            <Color3 name="TextColor3">1 1 1</Color3>
+            <string name="AccessibleDescription">Master volume setting.</string>
+          </Properties>
+        </Item>
+        <Item class="TextButton" name="VolumeDown">
+          <Properties>
+            <bool name="BackgroundTransparency">0.2</bool>
+            <UDim2 name="Size">
+              <XScale>0</XScale>
+              <XOffset>80</XOffset>
+              <YScale>0</YScale>
+              <YOffset>80</YOffset>
+            </UDim2>
+            <Enum name="Font">GothamBold</Enum>
+            <bool name="TextScaled">true</bool>
+            <string name="Text">-</string>
+            <Color3 name="TextColor3">1 1 1</Color3>
+            <bool name="Selectable">true</bool>
+            <string name="AccessibleDescription">Decrease volume.</string>
+          </Properties>
+        </Item>
+        <Item class="TextButton" name="VolumeUp">
+          <Properties>
+            <bool name="BackgroundTransparency">0.2</bool>
+            <UDim2 name="Size">
+              <XScale>0</XScale>
+              <XOffset>80</XOffset>
+              <YScale>0</YScale>
+              <YOffset>80</YOffset>
+            </UDim2>
+            <Enum name="Font">GothamBold</Enum>
+            <bool name="TextScaled">true</bool>
+            <string name="Text">+</string>
+            <Color3 name="TextColor3">1 1 1</Color3>
+            <bool name="Selectable">true</bool>
+            <string name="AccessibleDescription">Increase volume.</string>
+          </Properties>
+        </Item>
+      </Item>
+    </Item>
+  </Item>
+</roblox>

--- a/StarterGui/Vote.gui
+++ b/StarterGui/Vote.gui
@@ -1,0 +1,89 @@
+<roblox version="4">
+  <Item class="ScreenGui" name="Vote">
+    <Properties>
+      <bool name="ResetOnSpawn">false</bool>
+      <bool name="IgnoreGuiInset">true</bool>
+      <string name="Name">Vote</string>
+    </Properties>
+    <Item class="Frame" name="SafeArea">
+      <Properties>
+        <bool name="BackgroundTransparency">0.3</bool>
+        <Vector2 name="AnchorPoint">
+          <X>0.5</X>
+          <Y>0.5</Y>
+        </Vector2>
+        <UDim2 name="Position">
+          <XScale>0.5</XScale>
+          <XOffset>0</XOffset>
+          <YScale>0.5</YScale>
+          <YOffset>0</YOffset>
+        </UDim2>
+        <UDim2 name="Size">
+          <XScale>0.9</XScale>
+          <XOffset>0</XOffset>
+          <YScale>0.9</YScale>
+          <YOffset>0</YOffset>
+        </UDim2>
+        <bool name="SelectionGroup">true</bool>
+      </Properties>
+      <Item class="UIListLayout" name="Layout">
+        <Properties>
+          <Enum name="FillDirection">Horizontal</Enum>
+          <Enum name="HorizontalAlignment">Center</Enum>
+          <number name="Padding">20</number>
+        </Properties>
+      </Item>
+      <Item class="TextButton" name="MapAButton">
+        <Properties>
+          <bool name="BackgroundTransparency">0.2</bool>
+          <UDim2 name="Size">
+            <XScale>0</XScale>
+            <XOffset>200</XOffset>
+            <YScale>0</YScale>
+            <YOffset>100</YOffset>
+          </UDim2>
+          <Enum name="Font">GothamBold</Enum>
+          <bool name="TextScaled">true</bool>
+          <string name="Text">Depot</string>
+          <Color3 name="TextColor3">1 1 1</Color3>
+          <bool name="Selectable">true</bool>
+          <string name="AccessibleDescription">Vote for Steelhide Depot.</string>
+        </Properties>
+      </Item>
+      <Item class="TextButton" name="MapBButton">
+        <Properties>
+          <bool name="BackgroundTransparency">0.2</bool>
+          <UDim2 name="Size">
+            <XScale>0</XScale>
+            <XOffset>200</XOffset>
+            <YScale>0</YScale>
+            <YOffset>100</YOffset>
+          </UDim2>
+          <Enum name="Font">GothamBold</Enum>
+          <bool name="TextScaled">true</bool>
+          <string name="Text">Reserve</string>
+          <Color3 name="TextColor3">1 1 1</Color3>
+          <bool name="Selectable">true</bool>
+          <string name="AccessibleDescription">Vote for Blackpine Reserve.</string>
+        </Properties>
+      </Item>
+      <Item class="TextButton" name="MapCButton">
+        <Properties>
+          <bool name="BackgroundTransparency">0.2</bool>
+          <UDim2 name="Size">
+            <XScale>0</XScale>
+            <XOffset>200</XOffset>
+            <YScale>0</YScale>
+            <YOffset>100</YOffset>
+          </UDim2>
+          <Enum name="Font">GothamBold</Enum>
+          <bool name="TextScaled">true</bool>
+          <string name="Text">Wing</string>
+          <Color3 name="TextColor3">1 1 1</Color3>
+          <bool name="Selectable">true</bool>
+          <string name="AccessibleDescription">Vote for St. Verity Wing.</string>
+        </Properties>
+      </Item>
+    </Item>
+  </Item>
+</roblox>


### PR DESCRIPTION
## Summary
- add HUD screen with safe-area labels for health and stamina
- add menu, vote, results, and settings screens with console-safe layouts and accessibility descriptions

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a67b271c44832fb0b363099073210d